### PR TITLE
event(lite): 添加物品缓存事件处理

### DIFF
--- a/src/main/java/dev/anvilcraft/lite/event/InWorldRecipeEventListener.java
+++ b/src/main/java/dev/anvilcraft/lite/event/InWorldRecipeEventListener.java
@@ -1,6 +1,7 @@
 package dev.anvilcraft.lite.event;
 
 import dev.anvilcraft.lib.event.InWorldRecipeManagerEvent;
+import dev.anvilcraft.lib.event.ItemCacheEvent;
 import dev.anvilcraft.lib.recipe.InWorldRecipe;
 import dev.anvilcraft.lite.AnvilCraftLite;
 import dev.anvilcraft.lite.recipe.anvil.wrap.VanillaRecipesWrap;
@@ -18,5 +19,10 @@ public class InWorldRecipeEventListener {
         RecipeManager manager = event.getRecipeManager();
         List<RecipeHolder<InWorldRecipe>> init = VanillaRecipesWrap.init(manager.anvillib$getRegistries(), manager.getRecipes());
         manager.anvillib$addRecipes(init);
+    }
+
+    @SubscribeEvent
+    public static void inWorldRecipe(ItemCacheEvent.SpawnItemEntity event) {
+        event.getEntity().anvilcraftLite$setIsAdsorbable(false);
     }
 }


### PR DESCRIPTION
- 在 InWorldRecipeEventListener 类中添加 ItemCacheEvent.SpawnItemEntity 事件的处理方法
- 设置新生成的物品实体为不可吸附，以防止其被磁化节点吸附