### PR TITLE
fix(dispense): 修复空桶填充行为

### DIFF
--- a/src/main/java/dev/anvilcraft/lite/dispense/EmptyBucketBehavior.java
+++ b/src/main/java/dev/anvilcraft/lite/dispense/EmptyBucketBehavior.java
@@ -28,13 +28,13 @@ public class EmptyBucketBehavior implements ModDispenseItemBehavior {
         if (blockState.is(Blocks.WATER_CAULDRON) && blockState.getValue(LayeredCauldronBlock.LEVEL) == 3) {
             level.setBlockAndUpdate(pos1, Blocks.CAULDRON.defaultBlockState());
             return Items.WATER_BUCKET.getDefaultInstance();
-        } else if (blockState.is(Blocks.WATER) && blockState.getValue(LiquidBlock.LEVEL) == 15) {
+        } else if (blockState.is(Blocks.WATER) && blockState.getValue(LiquidBlock.LEVEL) == 0) {
             level.setBlockAndUpdate(pos1, Blocks.AIR.defaultBlockState());
             return Items.WATER_BUCKET.getDefaultInstance();
         } else if (blockState.is(Blocks.LAVA_CAULDRON)) {
             level.setBlockAndUpdate(pos1, Blocks.CAULDRON.defaultBlockState());
             return Items.LAVA_BUCKET.getDefaultInstance();
-        } else if (blockState.is(Blocks.LAVA) && blockState.getValue(LiquidBlock.LEVEL) == 15) {
+        } else if (blockState.is(Blocks.LAVA) && blockState.getValue(LiquidBlock.LEVEL) == 0) {
             level.setBlockAndUpdate(pos1, Blocks.AIR.defaultBlockState());
             return Items.LAVA_BUCKET.getDefaultInstance();
         } else if (blockState.is(Blocks.POWDER_SNOW_CAULDRON)) {


### PR DESCRIPTION
- 修改水桶和岩浆桶的填充条件
- 从 LiquidBlock.LEVEL == 15 改为 LiquidBlock.LEVEL == 0
- 这个修改确保了桶能正确地从水源或岩浆源中取水