### PR TITLE
build: 更新 JEI 依赖类型

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,7 @@ dependencies {
 
     // JEI
     compileOnly "mezz.jei:jei-1.21.8-neoforge-api:24.0.0.2"
-    runtimeOnly "mezz.jei:jei-1.21.8-neoforge:24.0.0.2"
+    implementation "mezz.jei:jei-1.21.8-neoforge:24.0.0.2"
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.


### PR DESCRIPTION
- 将 JEI 的 runtimeOnly 依赖改为 implementation 依赖
- 这一变更可以确保 JEI 相关的类和方法在编译时可用，提高开发体验