### PR TITLE
ci: 更新构建和发布工作流中的文件路径

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,5 +94,5 @@ jobs:
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
 
           files: |
-            build/libs/anvilcraft-neoforge-${{ steps.version.outputs.version }}.jar
-            build/libs/anvilcraft-neoforge-${{ steps.version.outputs.version }}-sources.jar
+            build/libs/${{ steps.properties.outputs.mod_id }}-neoforge-1.21.8-${{ steps.version.outputs.version }}.jar
+            build/libs/${{ steps.properties.outputs.mod_id }}-neoforge-1.21.8-${{ steps.version.outputs.version }}-sources.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,5 +88,5 @@ jobs:
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
 
           files: |
-            build/libs/anvilcraft-neoforge-${{ steps.version.outputs.version }}.jar
-            build/libs/anvilcraft-neoforge-${{ steps.version.outputs.version }}-sources.jar
+            build/libs/${{ steps.properties.outputs.mod_id }}-neoforge-1.21.8-${{ steps.version.outputs.version }}.jar
+            build/libs/${{ steps.properties.outputs.mod_id }}-neoforge-1.21.8-${{ steps.version.outputs.version }}-sources.jar


### PR DESCRIPTION
- 在 ci.yml 和 release.yml 文件中，更新了构建产物的文件名格式
- 新格式包括了 mod_id 和 Minecraft 版本号（1.21.8）
- 这样可以提高构建产物的可识别性和版本兼容性