### PR TITLE
feat(blocks): 为磁铁块添加属性设置

### DIFF
--- a/src/main/java/dev/anvilcraft/lite/init/block/ModBlocks.java
+++ b/src/main/java/dev/anvilcraft/lite/init/block/ModBlocks.java
@@ -12,21 +12,28 @@ import static dev.anvilcraft.lite.AnvilCraftLite.REGISTER;
 
 public class ModBlocks {
     public static final DeferredBlock<ResinBlock> RESIN_BLOCK = REGISTER.block("resin_block", ResinBlock::new)
-        .properties(() -> Blocks.SLIME_BLOCK).lang("Block of Resin")
+        .properties(() -> Blocks.SLIME_BLOCK)
+        .lang("Block of Resin")
         .register();
 
     public static final DeferredBlock<MagnetBlock> MAGNET_BLOCK = REGISTER.block("magnet_block", MagnetBlock::new)
+        .properties(() -> Blocks.IRON_BLOCK)
         .lang("Block of Magnet")
         .register();
 
     public static final DeferredBlock<HollowMagnetBlock> HOLLOW_MAGNET_BLOCK = REGISTER.block("hollow_magnet_block", HollowMagnetBlock::new)
+        .properties(() -> Blocks.IRON_BLOCK)
         .lang("Hollowed Block of Magnet")
         .register();
 
     public static final DeferredBlock<FerriteCoreMagnetBlock> FERRITE_CORE_MAGNET_BLOCK = REGISTER.block(
         "ferrite_core_magnet_block",
         FerriteCoreMagnetBlock::new
-    ).properties(BlockBehaviour.Properties::randomTicks).lang("Ferrite-Cored Block of Magnet").register();
+        )
+        .properties(() -> Blocks.IRON_BLOCK)
+        .properties(BlockBehaviour.Properties::randomTicks)
+        .lang("Ferrite-Cored Block of Magnet")
+        .register();
 
     public static void init() {
     }


### PR DESCRIPTION
- 为 RESIN_BLOCK、MAGNET_BLOCK、HOLLOW_MAGNET_BLOCK 和 FERRITE_CORE_MAGNET_BLOCK 添加属性设置
- 使 FERRITE_CORE_MAGNET_BLOCK 具有随机刻
- 优化代码格式，提高可读性